### PR TITLE
Player correctly render on screen

### DIFF
--- a/ultimate_tag.asm
+++ b/ultimate_tag.asm
@@ -28,7 +28,7 @@ Initialize                  ; Defines the Initialize subroutine.
     STA ComputerDirection   ; Sets the NPC facing left.
     JSR SetItColours        ; Go to subroutine to set the colours for who is it.
 
-    LDA #$9F                ; Loads background colour into the accumulator.
+    LDA #$9F                ; Loads background colour (light blue) into the accumulator.
     STA COLUBK              ; Sets the background colour register in the TIA.
 
     LDA #2                  ; Sets the binary value #%0000_0010, which will turn on VBLANK and VSYNC.

--- a/ultimate_tag.asm
+++ b/ultimate_tag.asm
@@ -24,8 +24,8 @@ Initialize                  ; Defines the Initialize subroutine.
     CLEAN_START             ; Calls the CLEAN_START macro from macro.h.
 
     ; Accumulator starts at 0 from the CLEAN_START macro.
-    STA ComputerDirection   ; Sets the NPC facing left.
     STA PlayerIt            ; Sets the player to it.
+    STA ComputerDirection   ; Sets the NPC facing left.
     JSR SetItColours        ; Go to subroutine to set the colours for who is it.
 
     LDA #$9F                ; Loads background colour into the accumulator.
@@ -87,7 +87,7 @@ HBlankPeriod
     BMI PrintingPeriod
 
 PrintComputer
-    LDA #ComputerDirection  ; If 0, computer is facing left; if non-zero, computer is facing right.
+    LDA ComputerDirection   ; If 0, computer is facing left; if non-zero, computer is facing right.
     BNE PrintComputerRight
 
 PrintComputerLeft
@@ -147,12 +147,12 @@ OverscanLoop
 
 ; Subroutine to set the colours for who is it.
 SetItColours
-    LDA #PlayerIt           ; Load the PlayerIt value into the accumulator.
+    LDA PlayerIt            ; Load the PlayerIt value into the accumulator.
     BNE ComputerRed         ; Go to ComputerRed if the value is non-zero.
 
 PlayerRed
     STA COLUP1              ; Accumulator is zero at this point; set NPC to black.
-    LDA #$32                ; Load red into accumulator..
+    LDA #$32                ; Load red into accumulator.
     STA COLUP0              ; Set player colour register to red.
     RTS                     ; Return.
 


### PR DESCRIPTION
How, this was like...15 hours of work. But, I've managed to "race the beam" and have two sprites render depending on their Y positioning correctly. The real problem was getting them to both work within the same horizontal space. If neither sprite shared any horizontal space, there was enough clock cycles. But, if they shared any horizontal space, the code would keep going through the next output cycle and mess up, causing duplicated lines.

I fixed this by loading the sprite into the zero-page indexed RAM to save on clock cycles on the loading time.